### PR TITLE
Add CyberHost Malware Blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ Please note that blocklists lacking active maintenance or those containing relat
 [blocklistproject.scam.raw]: https://blocklistproject.github.io/Lists/alt-version/scam-nl.txt
 
 [CyberHost]: https://cyberhost.uk/malware-blocklist
-[URLhaus.raw]: https://lists.cyberhost.uk/malware.txt
+[CyberHost.raw]: https://lists.cyberhost.uk/malware.txt

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Please note that blocklists lacking active maintenance or those containing relat
 | Badd-Boyz-Hosts             | Mitchell Krog          | A hosts file to block bad domains                         | [Link][Badd-Boyz-Hosts]             | MIT                             | [Raw][Badd-Boyz-Hosts.raw]             |
 | blackbook                   | Miroslav Stampar       | Blackbook of malware domains                              | [Link][blackbook]                   | Public Domain                   | [Raw][blackbook.raw]                   |
 | CoinBlockerLists            | ZeroDot1               | Simple list that help prevent cryptomining                | [Link][CoinBlockerLists]            | AGPLv3                          | [Raw][CoinBlockerLists.raw]            |
+| Malware and Phishing        | CyberHost              | List of malware and phishing domains                      | [Link][CyberHost]                   | CC BY-SA 4.0                    | [Raw][CyberHost.raw]                   |
 | eth-phishing-detect         | MetaMask               | Phishing domains targeting Ethereum users                 | [Link][eth-phishing-detect]         | DON'T BE A DICK PUBLIC LICENSE  | [Raw][eth-phishing-detect.raw]         |
 | Fraud block list            | The Block List Project | Lists of sites created to fraud                           | [Link][The Block List Project]      | The Unlicense license           | [Raw][blocklistproject.fraud.raw]      |
 | GlobalAntiScamOrg-blocklist | Wu Tingfeng            | Global Anti Scam Organization blocklist                   | [Link][GlobalAntiScamOrg-blocklist] | BSD-3-Clause                    | [Raw][GlobalAntiScamOrg-blocklist.raw] |
@@ -133,3 +134,6 @@ Please note that blocklists lacking active maintenance or those containing relat
 [blocklistproject.phishing.raw]: https://blocklistproject.github.io/Lists/alt-version/phishing-nl.txt
 [blocklistproject.ransomware.raw]: https://blocklistproject.github.io/Lists/alt-version/ransomware-nl.txt
 [blocklistproject.scam.raw]: https://blocklistproject.github.io/Lists/alt-version/scam-nl.txt
+
+[CyberHost]: https://cyberhost.uk/malware-blocklist
+[URLhaus.raw]: https://lists.cyberhost.uk/malware.txt


### PR DESCRIPTION
Hi Peter,

I've recently been putting together a malware and phishing blocklist, this is via collecting public threat intelligence reporting and via mastodon/twitter infosec groups.

Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new “CyberHost Malware Domains” entry to the Blocklists table, including source, description (malware and phishing domains), license (CC BY-SA 4.0), and links to the list and raw feed.
  - Introduced two new reference links for CyberHost and its raw data.
  - No changes to exported/public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->